### PR TITLE
feat: add hasthumbnail setting to true

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -109,8 +109,9 @@ const plugin: FastifyPluginAsync<GraaspPluginFileItemOptions> = async (
           },
         },
         settings: {
-          hasThumbnail: true // TODO: depend on mimetype
-        }
+          // image files get automatically generated thumbnails
+          hasThumbnail: mimetype.startsWith('image'),
+        },
       };
       // create corresponding item
       const tasks = itemTaskManager.createCreateTaskSequence(


### PR DESCRIPTION
close #24 

I think there's a possibility for plugin-thumbnails to be included in this repo, which would avoid spreading too much the `hasThumbnail` setting.